### PR TITLE
Remove leftover download names button

### DIFF
--- a/index.html
+++ b/index.html
@@ -703,7 +703,6 @@
 
     <!-- İlişkiler Butonu -->
     <button id="relationships-toggle" style="position: fixed; top: 10px; left: 10px; z-index: 999; background: rgba(116, 185, 255, 0.8); border: none; color: white; padding: 8px; border-radius: 5px; cursor: pointer;">👥</button>
-    <button id="download-names" style="position: fixed; top: 50px; left: 10px; z-index: 999; background: rgba(0, 150, 136, 0.8); border: none; color: white; padding: 8px; border-radius: 5px; cursor: pointer;">💾</button>
     <!-- Lider Paneli Butonu -->
     <button id="leader-toggle">📊</button>
 
@@ -1222,22 +1221,6 @@
             const names = JSON.parse(localStorage.getItem(NAME_STORAGE_KEY)) || [];
             names.push(name);
             localStorage.setItem(NAME_STORAGE_KEY, JSON.stringify(names));
-        }
-
-        function downloadNames() {
-            const names = JSON.parse(localStorage.getItem(NAME_STORAGE_KEY)) || [];
-            if (names.length === 0) {
-                alert('Kayıtlı isim yok.');
-                return;
-            }
-            const csv = names.map((n, i) => `${i + 1},${n}`).join('\n');
-            const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-            const link = document.createElement('a');
-            link.href = URL.createObjectURL(blob);
-            link.download = 'names.csv';
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
         }
 
         // === HİKAYE VERİSİ (JSON formatında) ===
@@ -1916,7 +1899,6 @@
             board.classList.toggle('hidden');
         });
 
-        document.getElementById('download-names').addEventListener('click', downloadNames);
         
         // Lore tooltip için event listener
         document.addEventListener('click', (e) => {
@@ -1932,7 +1914,6 @@
                 if (tooltips[term]) {
                     showLoreTooltip(tooltips[term], e.pageX, e.pageY);
                 }
-            } else {
                 hideLoreTooltip();
             }
         });


### PR DESCRIPTION
## Summary
- remove the button that let players download saved names
- clean up unused downloadNames function and event listener

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687500308ba88332b1b8a204f65015a5